### PR TITLE
Fix movement helpers and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The [Quick Start Coding Guide](https://docs.battlesnake.com/guides/getting-start
 
 ## Customizing Your Battlesnake
 
-Locate the `handle_info` function inside [server.py](server.py#L15). At the end of that function you should see a line that looks like this:
+Locate the `handle_info` function inside [server.py](server.py). At the end of that function you should see a line that looks like this:
 
 ```python
 return {
@@ -42,7 +42,7 @@ Whenever you update these values, go to the page for your Battlesnake and select
 
 On every turn of each game your Battlesnake receives information about the game board and must decide its next move.
 
-Locate the `handle_move` function inside [server.py](server.py#L48). Possible moves are "up", "down", "left", or "right". To start your Battlesnake will choose a move randomly. Your goal as a developer is to read information sent to you about the board (available in the `data` variable) and decide where your Battlesnake should move next. Your Battlesnakes move logic lives in [server_logic.py](server_logic.py#L37). This is the code you will want to edit.
+Locate the `handle_move` function inside [server.py](server.py). Possible moves are "up", "down", "left", or "right". To start your Battlesnake will choose a move randomly. Your goal as a developer is to read information sent to you about the board (available in the `data` variable) and decide where your Battlesnake should move next. Your Battlesnakes move logic lives in [server_logic.py](server_logic.py). This is the code you will want to edit.
 
 See the [Battlesnake Game Rules](https://docs.battlesnake.com/references/rules) for more information on playing the game, moving around the board, and improving your algorithm.
 

--- a/board.py
+++ b/board.py
@@ -76,7 +76,7 @@ class Board:
         elif choice[1] == my_head["y"] and  my_head["x"] == choice[0] - 1 and "right" in possible_moves:
             return "right"
 
-    def chose_direction(self, my_snake:Snake):
+    def choose_direction(self, my_snake:Snake):
         board = self
         food : List = board.food
         my_health = my_snake.health
@@ -154,11 +154,11 @@ class Board:
         my_head = my_snake.head
         if "left" in possible_moves and  my_head["x"] == 0:
             possible_moves.remove("left")
-        if "right" in possible_moves and  my_head["x"] == board.height - 1:
+        if "right" in possible_moves and  my_head["x"] == board.width - 1:
             possible_moves.remove("right")
         if "down" in possible_moves and my_head["y"] == 0:
             possible_moves.remove("down")
-        if "up" in possible_moves and  my_head["y"] == board.width - 1:
+        if "up" in possible_moves and  my_head["y"] == board.height - 1:
             possible_moves.remove("up")
         return possible_moves
 

--- a/server_logic.py
+++ b/server_logic.py
@@ -3,7 +3,7 @@ from board import Board
 
 def choose_move(data: dict) -> str:
     board:Board = Board(data)
-    move = board.chose_direction(board.you)
+    move = board.choose_direction(board.you)
     
     print(f"{data['game']['id']} MOVE {data['turn']}: {move} picked")
 

--- a/tests.py
+++ b/tests.py
@@ -12,7 +12,32 @@ in the folder where this file exists:
 """
 import unittest
 
-from server_logic import avoid_my_neck
+from board import Board
+from snake import Snake
+
+
+def create_board(head: dict, body: list) -> Board:
+    snake_data = {
+        "id": "test-snake",
+        "name": "snek",
+        "head": head,
+        "body": body,
+        "health": 100,
+        "latency": "0",
+    }
+    data = {
+        "game": {"id": "test-game"},
+        "turn": 0,
+        "board": {
+            "height": 11,
+            "width": 11,
+            "food": [],
+            "hazards": [],
+            "snakes": [snake_data],
+        },
+        "you": snake_data,
+    }
+    return Board(data)
 
 
 class AvoidNeckTest(unittest.TestCase):
@@ -26,24 +51,23 @@ class AvoidNeckTest(unittest.TestCase):
         # Arrange
         test_head = {"x": 5, "y": 5}
         test_body = [{"x": 5, "y": 5}, {"x": 5, "y": 5}, {"x": 5, "y": 5}]
-        possible_moves = ["up", "down", "left", "right"]
-
+        board = create_board(test_head, test_body)
         # Act
-        result_moves = avoid_my_neck(test_head, test_body, possible_moves)
+        result_moves = board.avoid_my_neck(board.you)
 
         # Assert
         self.assertEqual(len(result_moves), 4)
-        self.assertEqual(possible_moves, result_moves)
+        self.assertEqual(["up", "down", "left", "right"], result_moves)
 
     def test_avoid_neck_left(self):
         # Arrange
         test_head = {"x": 5, "y": 5}
         test_body = [{"x": 5, "y": 5}, {"x": 4, "y": 5}, {"x": 3, "y": 5}]
-        possible_moves = ["up", "down", "left", "right"]
         expected = ["up", "down", "right"]
 
+        board = create_board(test_head, test_body)
         # Act
-        result_moves = avoid_my_neck(test_head, test_body, possible_moves)
+        result_moves = board.avoid_my_neck(board.you)
 
         # Assert
         self.assertEqual(len(result_moves), 3)
@@ -53,11 +77,11 @@ class AvoidNeckTest(unittest.TestCase):
         # Arrange
         test_head = {"x": 5, "y": 5}
         test_body = [{"x": 5, "y": 5}, {"x": 6, "y": 5}, {"x": 7, "y": 5}]
-        possible_moves = ["up", "down", "left", "right"]
         expected = ["up", "down", "left"]
 
+        board = create_board(test_head, test_body)
         # Act
-        result_moves = avoid_my_neck(test_head, test_body, possible_moves)
+        result_moves = board.avoid_my_neck(board.you)
 
         # Assert
         self.assertEqual(len(result_moves), 3)
@@ -67,11 +91,11 @@ class AvoidNeckTest(unittest.TestCase):
         # Arrange
         test_head = {"x": 5, "y": 5}
         test_body = [{"x": 5, "y": 5}, {"x": 5, "y": 6}, {"x": 5, "y": 7}]
-        possible_moves = ["up", "down", "left", "right"]
         expected = ["down", "left", "right"]
 
+        board = create_board(test_head, test_body)
         # Act
-        result_moves = avoid_my_neck(test_head, test_body, possible_moves)
+        result_moves = board.avoid_my_neck(board.you)
 
         # Assert
         self.assertEqual(len(result_moves), 3)
@@ -81,15 +105,29 @@ class AvoidNeckTest(unittest.TestCase):
         # Arrange
         test_head = {"x": 5, "y": 5}
         test_body = [{"x": 5, "y": 5}, {"x": 5, "y": 4}, {"x": 5, "y": 3}]
-        possible_moves = ["up", "down", "left", "right"]
         expected = ["up", "left", "right"]
 
+        board = create_board(test_head, test_body)
         # Act
-        result_moves = avoid_my_neck(test_head, test_body, possible_moves)
+        result_moves = board.avoid_my_neck(board.you)
 
         # Assert
         self.assertEqual(len(result_moves), 3)
         self.assertEqual(expected, result_moves)
+
+    def test_avoid_neck_diagonal(self):
+        """Body diagonally adjacent should not restrict moves."""
+        # Arrange
+        test_head = {"x": 5, "y": 5}
+        test_body = [{"x": 5, "y": 5}, {"x": 6, "y": 6}, {"x": 7, "y": 7}]
+
+        board = create_board(test_head, test_body)
+        # Act
+        result_moves = board.avoid_my_neck(board.you)
+
+        # Assert
+        self.assertEqual(len(result_moves), 4)
+        self.assertEqual(["up", "down", "left", "right"], result_moves)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- rename `chose_direction` to `choose_direction`
- correct board boundary checks
- update README line references
- repair neck-avoidance tests and add diagonal case

## Testing
- `python tests.py -v`
- `python -m py_compile board.py server_logic.py tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684871d203f8832a99c6c133df55e7b6